### PR TITLE
feat(permissions): Additional resource permissions [ENG-45898]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ module "service_account_creation" {
   gcp_org_domain = "YOUR_ORGANIZATION_DOMAIN"
   # gcp_project_id = "YOUR_PROJECT_ID" # if it's unset, the project by default is used
   # drata_role_name = "YOUR_ROLE_NAME" # if it's unset, the default name is DrataReadOnly
+  # connect_multiple_projects = false # if it's unset, the default value is true
 }
 
 output "drata_service_account_key" {
@@ -37,9 +38,10 @@ The following steps demonstrate how to connect GCP in Drata when using this terr
 4. Replace `YOUR_ORGANIZATION_DOMAIN` with the GCP organization domain.
 5. Replace `YOUR_PROJECT_ID` if the desired project is not the default project in your organization.
 6. Replace the given `drata_role_name` if you don't want the role added to be the default: `DrataReadOnly`.
-7. Back in your terminal, run `terraform init` to download/update the module.
-8. Run `terraform apply` and **IMPORTANT** review the plan output before typing `yes`.
-9. If successful, run the command to generate the json key file 
+7. If you don't wish to connect multiple projects to Drata the `connect_multiple_projects` variable must be `false` otherwise `true` or unset.
+8. Back in your terminal, run `terraform init` to download/update the module.
+9. Run `terraform apply` and **IMPORTANT** review the plan output before typing `yes`.
+10. If successful, run the command to generate the json key file 
      - `terraform output -raw drata_service_account_key > drata-gcp-private-key.json` .
 11. Verify the file has been generated.
 12. Go to the GCP connection drawer and select Upload File to upload the `drata-gcp-private-key.json` file.
@@ -68,10 +70,11 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_organization_iam_custom_role.drata_org_role](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_member.drata_organization_viewer_role](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.organization](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/organization_iam_member) | resource |
 | [google_project_iam_custom_role.drata_project_role](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_member.drata_member_project_role](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.drata_viewer_role](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.drata_project_viewer_role](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/project_iam_member) | resource |
 | [google_project_service.services](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/project_service) | resource |
 | [google_service_account.drata](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/service_account) | resource |
 | [google_service_account_key.drata_key](https://registry.terraform.io/providers/hashicorp/google/5.16.0/docs/resources/service_account_key) | resource |
@@ -82,6 +85,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_connect_multiple_projects"></a> [connect\_multiple\_projects](#input\_connect\_multiple\_projects) | Tells the service account whether it can see all the projects or not. | `bool` | `true` | no |
 | <a name="input_drata_role_name"></a> [drata\_role\_name](#input\_drata\_role\_name) | Role name. | `string` | `"DrataReadOnly"` | no |
 | <a name="input_gcp_org_domain"></a> [gcp\_org\_domain](#input\_gcp\_org\_domain) | GCP Organization domain. | `string` | n/a | yes |
 | <a name="input_gcp_project_id"></a> [gcp\_project\_id](#input\_gcp\_project\_id) | Project identifier of the gcp organization. If it is not provided, the provider project is used. | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -75,5 +75,5 @@ resource "google_organization_iam_member" "drata_organization_viewer_role" {
   org_id = data.google_organization.gcp_organization.org_id
   role   = "roles/viewer"
   member = "serviceAccount:${google_service_account.drata.email}"
-  count  = var.organization_access ? 1 : 0
+  count  = var.connect_multiple_projects ? 1 : 0
 }

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "google_organization_iam_custom_role" "drata_org_role" {
   role_id     = "${var.drata_role_name}OrganizationalRole"
   title       = "Drata Read-Only Organizational Role"
   description = "Service Account with read-only access for Drata Autopilot to get organizational IAM data"
-  permissions = ["resourcemanager.organizations.getIamPolicy", "storage.buckets.get", "storage.buckets.getIamPolicy"]
+  permissions = ["resourcemanager.organizations.getIamPolicy", "storage.buckets.get", "storage.buckets.getIamPolicy", "resourcemanager.folders.get", "resourcemanager.organizations.get"]
   org_id      = data.google_organization.gcp_organization.org_id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -72,8 +72,8 @@ resource "google_project_iam_member" "drata_project_viewer_role" {
 }
 # organization viewer role
 resource "google_organization_iam_member" "drata_organization_viewer_role" {
+  count  = var.connect_multiple_projects ? 1 : 0
   org_id = data.google_organization.gcp_organization.org_id
   role   = "roles/viewer"
   member = "serviceAccount:${google_service_account.drata.email}"
-  count  = var.connect_multiple_projects ? 1 : 0
 }

--- a/main.tf
+++ b/main.tf
@@ -52,21 +52,28 @@ resource "google_service_account_key" "drata_key" {
 }
 
 # assignation of roles to the service account
-# project role
+# project custom role
 resource "google_project_iam_member" "drata_member_project_role" {
   project = local.PROJECT_ID
   role    = google_project_iam_custom_role.drata_project_role.name
   member  = "serviceAccount:${google_service_account.drata.email}"
 }
-# organization role
+# organization custom role
 resource "google_organization_iam_member" "organization" {
   org_id = data.google_organization.gcp_organization.org_id
   role   = google_organization_iam_custom_role.drata_org_role.name
   member = "serviceAccount:${google_service_account.drata.email}"
 }
-# viewer role
-resource "google_project_iam_member" "drata_viewer_role" {
+# project viewer role
+resource "google_project_iam_member" "drata_project_viewer_role" {
   project = local.PROJECT_ID
   role    = "roles/viewer"
   member  = "serviceAccount:${google_service_account.drata.email}"
+}
+# organization viewer role
+resource "google_organization_iam_member" "drata_organization_viewer_role" {
+  org_id = data.google_organization.gcp_organization.org_id
+  role   = "roles/viewer"
+  member = "serviceAccount:${google_service_account.drata.email}"
+  count  = var.organization_access ? 1 : 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,9 +9,9 @@ variable "gcp_org_domain" {
   description = "GCP Organization domain."
 }
 
-variable "organization_access" {
+variable "connect_multiple_projects" {
   type        = bool
-  description = "Tells the service account whether it can see the entire organization or not."
+  description = "Tells the service account whether it can see all the projects or not."
   default     = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "gcp_org_domain" {
   description = "GCP Organization domain."
 }
 
+variable "organization_access" {
+  type        = bool
+  description = "Tells the service account whether it can see the entire organization or not."
+  default     = true
+}
+
 variable "gcp_services" {
   type        = list(string)
   default     = ["cloudresourcemanager.googleapis.com", "compute.googleapis.com", "admin.googleapis.com", "sqladmin.googleapis.com", "monitoring.googleapis.com"]


### PR DESCRIPTION
## The Service Account needs additional permissions in order to read the folder and project names.

### It also needs another permission to be able to access to the entire organization projects, this may be configurable.

- The user can choose whether the service account gets access to the entire organization with the `connect_multiple_projects`, by default is a `yes`.
- The other permissions to read folders and projects are added in the policy. Check [here](https://github.com/drata/gcp-terraform-drata-setup/pull/3/commits/91f1ba5e97d8ee14b321e998cc2cde4126301358).

[ENG-45898](https://drata.atlassian.net/browse/ENG-45898)

### Changes on the README besides terraform docs.

- PIC 1
![image](https://github.com/drata/gcp-terraform-drata-setup/assets/22245919/b9115cba-76eb-4d25-98f5-df4a6602759c)
 
- PIC 2
![image](https://github.com/drata/gcp-terraform-drata-setup/assets/22245919/e0a43918-f3ad-4d7b-827d-4407d19f5794)

[ENG-45898]: https://drata.atlassian.net/browse/ENG-45898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ