### PR TITLE
feat(assets): add service and permission for Assets [ENG-45104]

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ No modules.
 | <a name="input_drata_role_name"></a> [drata\_role\_name](#input\_drata\_role\_name) | Role name. | `string` | `"DrataReadOnly"` | no |
 | <a name="input_gcp_org_domain"></a> [gcp\_org\_domain](#input\_gcp\_org\_domain) | GCP Organization domain. | `string` | n/a | yes |
 | <a name="input_gcp_project_id"></a> [gcp\_project\_id](#input\_gcp\_project\_id) | Project identifier of the gcp organization. If it is not provided, the provider project is used. | `string` | `null` | no |
-| <a name="input_gcp_services"></a> [gcp\_services](#input\_gcp\_services) | List of services to enable. | `list(string)` | <pre>[<br>  "cloudresourcemanager.googleapis.com",<br>  "compute.googleapis.com",<br>  "admin.googleapis.com",<br>  "sqladmin.googleapis.com",<br>  "monitoring.googleapis.com"<br>]</pre> | no |
+| <a name="input_gcp_services"></a> [gcp\_services](#input\_gcp\_services) | List of services to enable. | `list(string)` | <pre>[<br>  "cloudresourcemanager.googleapis.com",<br>  "compute.googleapis.com",<br>  "admin.googleapis.com",<br>  "sqladmin.googleapis.com",<br>  "monitoring.googleapis.com",<br>  "cloudasset.googleapis.com"<br>]</pre> | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "google_organization_iam_custom_role" "drata_org_role" {
   role_id     = "${var.drata_role_name}OrganizationalRole"
   title       = "Drata Read-Only Organizational Role"
   description = "Service Account with read-only access for Drata Autopilot to get organizational IAM data"
-  permissions = ["resourcemanager.organizations.getIamPolicy", "storage.buckets.get", "storage.buckets.getIamPolicy", "resourcemanager.folders.get", "resourcemanager.organizations.get"]
+  permissions = ["resourcemanager.organizations.getIamPolicy", "storage.buckets.get", "storage.buckets.getIamPolicy", "resourcemanager.folders.get", "resourcemanager.organizations.get", "cloudasset.assets.searchAllResources"]
   org_id      = data.google_organization.gcp_organization.org_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "connect_multiple_projects" {
 
 variable "gcp_services" {
   type        = list(string)
-  default     = ["cloudresourcemanager.googleapis.com", "compute.googleapis.com", "admin.googleapis.com", "sqladmin.googleapis.com", "monitoring.googleapis.com"]
+  default     = ["cloudresourcemanager.googleapis.com", "compute.googleapis.com", "admin.googleapis.com", "sqladmin.googleapis.com", "monitoring.googleapis.com", "cloudasset.googleapis.com"]
   description = "List of services to enable."
 }
 


### PR DESCRIPTION
The following changes were added in order for GCP to get virtual assets working:

* Add `cloudasset.assets.searchAllResources` to the organizational role.
* Enable `cloudasset.googleapis.com` service.

[Shell script PR reference](https://github.com/drata/gcp-shell-drata-setup/pull/3)

[ENG-45104](https://drata.atlassian.net/browse/ENG-45104)

[ENG-45104]: https://drata.atlassian.net/browse/ENG-45104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ