### PR TITLE
Output service account

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,6 +5,6 @@ output "drata_service_account_key" {
 }
 
 output "drata_service_account" {
-  value       = google_service_account.drata
+  value       = google_service_account.drata.email
   description = "Service Account Object"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "drata_service_account_key" {
   sensitive   = true
 }
 
-output "drata_service_account" {
+output "drata_service_account_email" {
   value       = google_service_account.drata.email
   description = "Service Account Object"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,3 +3,8 @@ output "drata_service_account_key" {
   description = "Service Account Key"
   sensitive   = true
 }
+
+output "drata_service_account" {
+  value       = google_service_account.drata
+  description = "Service Account Object"
+}


### PR DESCRIPTION
Output the service account.

I needed this to add the service account email to an access context manager access level (service perimeter).