### PR TITLE
feat(readme): changes in readme [ENG-48555]

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ terraform output -raw drata_service_account_key > drata-gcp-private-key.json
 
 1. Fixing `FAILED_PRECONDITION: Key creation is not allowed on this service account (type: constraints/iam.disableServiceAccountKeyCreation)` issue.
    * Go to the [IAM Organization Policies](https://console.cloud.google.com/iam-admin/orgpolicies) page.
-   * Make sure the project where the service account will be stored is selected top left in the console.
+   * Make sure the project where the service account will be stored is selected (top left in the console).
    * Type `Disable service account key creation` on the `🔽 Filter` bar and select the policy.
    * Click over `📝 MANAGE POLICY` button.
    * Go to `Policy source` and select the `Override parent's policy` option.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ terraform output -raw drata_service_account_key > drata-gcp-private-key.json
 
 1. Fixing `FAILED_PRECONDITION: Key creation is not allowed on this service account (type: constraints/iam.disableServiceAccountKeyCreation)` issue.
    * Go to the [IAM Organization Policies](https://console.cloud.google.com/iam-admin/orgpolicies) page.
+   * Make sure the project where the service account will be stored is selected top left in the console.
    * Type `Disable service account key creation` on the `🔽 Filter` bar and select the policy.
    * Click over `📝 MANAGE POLICY` button.
    * Go to `Policy source` and select the `Override parent's policy` option.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ After you apply this terraform, run the following command to retrieve the key fi
 terraform output -raw drata_service_account_key > drata-gcp-private-key.json
 ```
 
+## Troubleshooting
+
+1. Fixing `FAILED_PRECONDITION: Key creation is not allowed on this service account (type: constraints/iam.disableServiceAccountKeyCreation)` issue.
+   * Go to the [IAM Organization Policies](https://console.cloud.google.com/iam-admin/orgpolicies) page.
+   * Type `Disable service account key creation` on the `🔽 Filter` bar and select the policy.
+   * Click over `📝 MANAGE POLICY` button.
+   * Go to `Policy source` and select the `Override parent's policy` option.
+   * Scroll down a little and open up the `Enforced` rule.
+   * Make sure the `Enforcement` section is `Off`.
+   * Click `SET POLICY` to save changes.
+   * Run this script again.
+
 ## Setup
 
 The following steps demonstrate how to connect GCP in Drata when using this terraform module.

--- a/README.md
+++ b/README.md
@@ -28,19 +28,6 @@ After you apply this terraform, run the following command to retrieve the key fi
 terraform output -raw drata_service_account_key > drata-gcp-private-key.json
 ```
 
-## Troubleshooting
-
-1. Fixing `FAILED_PRECONDITION: Key creation is not allowed on this service account (type: constraints/iam.disableServiceAccountKeyCreation)` issue.
-   * Go to the [IAM Organization Policies](https://console.cloud.google.com/iam-admin/orgpolicies) page.
-   * Make sure the project where the service account will be stored is selected (top left in the console).
-   * Type `Disable service account key creation` on the `🔽 Filter` bar and select the policy.
-   * Click over `📝 MANAGE POLICY` button.
-   * Go to `Policy source` and select the `Override parent's policy` option.
-   * Scroll down a little and open up the `Enforced` rule.
-   * Make sure the `Enforcement` section is `Off`.
-   * Click `SET POLICY` to save changes.
-   * Run this script again.
-
 ## Setup
 
 The following steps demonstrate how to connect GCP in Drata when using this terraform module.
@@ -59,6 +46,19 @@ The following steps demonstrate how to connect GCP in Drata when using this terr
 11. Verify the file has been generated.
 12. Go to the GCP connection drawer and select Upload File to upload the `drata-gcp-private-key.json` file.
 13. Select the `Save & Test Connection` button.
+
+## Troubleshooting ⚠️
+
+1. Fixing `FAILED_PRECONDITION: Key creation is not allowed on this service account (type: constraints/iam.disableServiceAccountKeyCreation)` issue.
+   * Go to the [IAM Organization Policies](https://console.cloud.google.com/iam-admin/orgpolicies) page.
+   * Make sure the project where the service account will be stored is selected (top left in the console).
+   * Type `Disable service account key creation` on the `🔽 Filter` bar and select the policy.
+   * Click over `📝 MANAGE POLICY` button.
+   * Go to `Policy source` and select the `Override parent's policy` option.
+   * Scroll down a little and open up the `Enforced` rule.
+   * Make sure the `Enforcement` section is `Off`.
+   * Click `SET POLICY` to save changes.
+   * Run this script again.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements


### PR DESCRIPTION
Troubleshooting section is added. 
Its located right before the `Setup` section.
Should look like this ⬇️ 

## Troubleshooting ⚠️

1. Fixing `FAILED_PRECONDITION: Key creation is not allowed on this service account (type: constraints/iam.disableServiceAccountKeyCreation)` issue.
   * Go to the [IAM Organization Policies](https://console.cloud.google.com/iam-admin/orgpolicies) page.
   * Make sure the project where the service account will be stored is selected top (top left in the console).
   * Type `Disable service account key creation` on the `🔽 Filter` bar and select the policy.
   * Click over `📝 MANAGE POLICY` button.
   * Go to `Policy source` and select the `Override parent's policy` option.
   * Scroll down a little and open up the `Enforced` rule.
   * Make sure the `Enforcement` section is `Off`.
   * Click `SET POLICY` to save changes.
   * Run this script again.