### PR TITLE
Update google terraform versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.16.0"
+      version = ">=5.16.0, <6.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">=5.16.0, <6.0.0"
+      version = ">=5.16.0, <7.0.0"
     }
   }
 }


### PR DESCRIPTION
Before this change, the module requires a specific version of google's terraform module which makes drata's module incompatible with other modules.

This change relaxes the version constraint so that the Drata module can be used with other modules requiring google.