### PR TITLE
chore: allow google provider version 6.X

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.16.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
I also removed the minor version pinning, it was unexpected on my side.